### PR TITLE
Update servers.R add 2 more catalogues

### DIFF
--- a/R/servers.R
+++ b/R/servers.R
@@ -95,5 +95,7 @@ server_urls <- c(
   "https://data.ca.gov/",
   "https://data.chhs.ca.gov/",
   "http://data.whiterockcity.ca/",
-  "https://catalogue.data.gov.bc.ca"
+  "https://catalogue.data.gov.bc.ca",
+  "https://data.montreal.ca",
+  "https://www.donneesquebec.ca"
 )


### PR DESCRIPTION
## Description
Add City of Montreal and Province of Quebec

## Related Issue
http://donnees.ville.montreal.qc.ca was removed as part of Issue # 162 - updated URL is https://data.montreal.ca  

http://donnees.ville.sherbrooke.qc.ca was removed as part of Issue # 162 - this data is now hosted via provincial https://www.donneesquebec.ca 